### PR TITLE
트랙 상태, 기간 API 구현

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation project(':module-core')
     implementation 'org.springdoc:springdoc-openapi-starter-common:2.0.2'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/module-api/src/main/java/com/gdsc/common/config/SchedulingConfig.java
+++ b/module-api/src/main/java/com/gdsc/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.gdsc.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/module-api/src/main/java/com/gdsc/domain/track/controller/TrackController.java
+++ b/module-api/src/main/java/com/gdsc/domain/track/controller/TrackController.java
@@ -58,7 +58,7 @@ public class TrackController {
 
     @DeleteMapping
     public ResponseEntity<Void> deleteAllTrack(@AuthenticationPrincipal User user){
-        trackService.delete(user);
+        trackService.deleteAll(user);
 
         return ResponseEntity.noContent().build();
     }

--- a/module-api/src/main/java/com/gdsc/domain/track/model/TrackRequest.java
+++ b/module-api/src/main/java/com/gdsc/domain/track/model/TrackRequest.java
@@ -1,11 +1,19 @@
 package com.gdsc.domain.track.model;
 
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record TrackRequest(
         @NotBlank
-        String content
+        String content,
+        @NotBlank
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+        @NotBlank
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate
 ) {
 }

--- a/module-api/src/main/java/com/gdsc/domain/track/model/TrackResponse.java
+++ b/module-api/src/main/java/com/gdsc/domain/track/model/TrackResponse.java
@@ -1,17 +1,29 @@
 package com.gdsc.domain.track.model;
 
 import com.gdsc.domain.track.entity.Track;
+import com.gdsc.domain.track.entity.TrackStatus;
 import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
 
 @Builder
 public record TrackResponse(
         Long trackId,
-        String content
+        String content,
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate startDate,
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        LocalDate endDate,
+        TrackStatus trackStatus
 ) {
     public static TrackResponse of(Track track) {
         return TrackResponse.builder()
                 .trackId(track.getId())
                 .content(track.getContent())
+                .startDate(track.getStartDate())
+                .endDate(track.getEndDate())
+                .trackStatus(track.getTrackStatus())
                 .build();
     }
 }

--- a/module-api/src/main/java/com/gdsc/domain/track/service/TrackService.java
+++ b/module-api/src/main/java/com/gdsc/domain/track/service/TrackService.java
@@ -5,15 +5,18 @@ import com.gdsc.common.exception.ApplicationErrorType;
 import com.gdsc.domain.keyword.entity.Keyword;
 import com.gdsc.domain.keyword.service.KeywordService;
 import com.gdsc.domain.track.entity.Track;
+import com.gdsc.domain.track.entity.TrackStatus;
 import com.gdsc.domain.track.model.TrackRequest;
 import com.gdsc.domain.track.repo.TrackRepository;
 import com.gdsc.domain.user.entity.User;
 import com.gdsc.security.service.UserDetailService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.gdsc.common.exception.ApplicationErrorType.TRACK_NOT_FOUND;
@@ -31,6 +34,9 @@ public class TrackService {
     public Track save(TrackRequest trackRequest, User user){
         Track track = Track.builder()
                 .content(trackRequest.content())
+                .startDate(trackRequest.startDate())
+                .endDate(trackRequest.endDate())
+                .trackStatus(TrackStatus.PROCEEDING)
                 .user(user)
                 .build();
 
@@ -49,18 +55,12 @@ public class TrackService {
     }
 
     @Transactional
-    public void delete(User user){
+    public void deleteAll(User user){
         trackRepository.deleteByUser(user);
     }
 
     public Track findById(Long trackId) {
         return trackRepository.findById(trackId).orElseThrow(() -> new ApplicationErrorException(TRACK_NOT_FOUND, "해당 트랙을 찾을 수 없습니다."));
-    }
-
-    public List<Track> findByKeywordContent(String keywordContent){
-        Keyword keyword = keywordService.findByContent(keywordContent);
-
-        return trackRepository.findByKeyword(keyword).orElseThrow(() -> new ApplicationErrorException(TRACK_NOT_FOUND, "해당 트랙을 찾을 수 없습니다."));
     }
 
     public List<Track> findByUser(User user){
@@ -72,6 +72,26 @@ public class TrackService {
 
         return trackRepository.findByKeyword(keyword)
                 .orElseThrow(() -> new ApplicationErrorException(TRACK_NOT_FOUND, "해당 트랙을 찾을 수 없습니다."));
+    }
+
+    public List<Track> findByTrackStatus(TrackStatus trackStatus){
+        return trackRepository.findByTrackStatus(trackStatus).orElseThrow(() -> new ApplicationErrorException(TRACK_NOT_FOUND, "해당 트랙을 찾을 수 없습니다."));
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void updateTrackStatusByEndDate(){
+        List<Track> tracks = findByTrackStatus(TrackStatus.PROCEEDING);
+
+        LocalDate currentDate = LocalDate.now();
+
+        List<Track> expiredTracks = tracks.stream()
+                .filter(track -> currentDate.isAfter(track.getEndDate()))
+                .toList();
+
+        for(Track track:expiredTracks){
+            track.updateTrackStatus(TrackStatus.EXPIRATION);
+        }
     }
 
     private boolean isNotSameWriter(Track track, User user) {

--- a/module-api/src/main/resources/data.sql
+++ b/module-api/src/main/resources/data.sql
@@ -7,10 +7,10 @@ INSERT INTO keyword (keyword_num,user_id,keyword_content) VALUES (5,1,"경제적
 INSERT INTO keyword (keyword_num,user_id,keyword_content) VALUES (6,1,"자존감");
 INSERT INTO keyword (keyword_num,user_id,keyword_content) VALUES (7,1,"미래에 대한 불안감");
 INSERT INTO keyword (keyword_num,user_id,keyword_content) VALUES (8,1,"건강");
-INSERT INTO track (track_num,track_content,user_id,keyword_id) VALUES (1,"나를 가꾸는 시간",1,8);
-INSERT INTO track (track_num,track_content,user_id,keyword_id) VALUES (2,"불면증 극복",1,8);
-INSERT INTO track (track_num,track_content,user_id,keyword_id) VALUES (3,"우울증 완화",1,8);
-INSERT INTO track (track_num,track_content,user_id,keyword_id) VALUES (4,"가족과의 시간",1,8);
+INSERT INTO track (track_num,track_content,track_status,track_start_date,track_end_date,user_id,keyword_id) VALUES (1,"나를 가꾸는 시간","EXPIRATION","2024-1-1","2024-12-31",1,8);
+INSERT INTO track (track_num,track_content,track_status,track_start_date,track_end_date,user_id,keyword_id) VALUES (2,"불면증 극복","EXPIRATION","2024-1-1","2024-12-31",1,8);
+INSERT INTO track (track_num,track_content,track_status,track_start_date,track_end_date,user_id,keyword_id) VALUES (3,"우울증 완화","EXPIRATION","2024-1-1","2024-12-31",1,8);
+INSERT INTO track (track_num,track_content,track_status,track_start_date,track_end_date,user_id,keyword_id) VALUES (4,"가족과의 시간","PROCEEDING","2024-1-1","2024-02-12",1,8);
 INSERT INTO routine (routine_num,routine_content,routine_status,user_id,track_id) VALUES (1,"좋아하는 음악","PROCEEDING",1,1);
 INSERT INTO routine (routine_num,routine_content,routine_status,user_id,track_id) VALUES (2,"샤워","PROCEEDING",1,1);
 INSERT INTO routine (routine_num,routine_content,routine_status,user_id,track_id) VALUES (3,"스킨케어","PROCEEDING",1,1);

--- a/module-api/src/test/java/com/gdsc/docs/util/RestDocsTest.java
+++ b/module-api/src/test/java/com/gdsc/docs/util/RestDocsTest.java
@@ -1,5 +1,6 @@
 package com.gdsc.docs.util;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.gdsc.docs.config.RestDocsConfig;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,6 +35,7 @@ public class RestDocsTest {
     }
 
     protected String createJson(Object dto) throws JsonProcessingException {
+        objectMapper.registerModule(new JavaTimeModule());
         return objectMapper.writeValueAsString(dto);
     }
 }

--- a/module-api/src/test/java/com/gdsc/domain/track/controller/TrackControllerTest.java
+++ b/module-api/src/test/java/com/gdsc/domain/track/controller/TrackControllerTest.java
@@ -1,8 +1,5 @@
 package com.gdsc.domain.track.controller;
 
-import com.gdsc.domain.keyword.controller.KeywordController;
-import com.gdsc.domain.keyword.model.KeywordRequest;
-import com.gdsc.domain.keyword.service.KeywordService;
 import com.gdsc.domain.track.model.TrackRequest;
 import com.gdsc.domain.track.service.TrackService;
 import com.gdsc.domain.user.entity.User;
@@ -58,7 +55,9 @@ class TrackControllerTest extends RestDocsTest {
                         getDocumentResponse(),
                         getAuthorizationHeader(),
                         requestFields(
-                                fieldWithPath("content").type(JsonFieldType.STRING).description("트랙 내용")
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("트랙 내용"),
+                                fieldWithPath("startDate").type(JsonFieldType.STRING).description("시작 날짜"),
+                                fieldWithPath("endDate").type(JsonFieldType.STRING).description("종료 날짜")
                         )));
     }
 
@@ -83,7 +82,7 @@ class TrackControllerTest extends RestDocsTest {
     @WithAuthUser
     void get_init_tracks() throws Exception {
         //given
-        given(trackService.findByKeywordContent("키워드1")).willReturn(트랙_초기_리스트);
+        given(trackService.findByKeyword("키워드1")).willReturn(트랙_초기_리스트);
         //when & then
         mvc.perform(get(REQUEST_URL + "/{keyword}", "키워드1")
                         .queryParam("keyword", "키워드")
@@ -130,7 +129,10 @@ class TrackControllerTest extends RestDocsTest {
     private static ResponseFieldsSnippet responseFieldsByUserTrack() {
         return responseFields(
                 fieldWithPath("trackId").type(JsonFieldType.NUMBER).description("트랙 id"),
-                fieldWithPath("content").type(JsonFieldType.STRING).description("트랙 내용")
+                fieldWithPath("content").type(JsonFieldType.STRING).description("트랙 내용"),
+                fieldWithPath("startDate").type(JsonFieldType.STRING).description("시작 날짜"),
+                fieldWithPath("endDate").type(JsonFieldType.STRING).description("종료 날짜"),
+                fieldWithPath("trackStatus").type(JsonFieldType.STRING).description("트랙 상태")
         );
     }
 
@@ -138,7 +140,10 @@ class TrackControllerTest extends RestDocsTest {
         return responseFields(
                 fieldWithPath("[]").type(JsonFieldType.ARRAY).description("트랙 리스트"),
                 fieldWithPath("[].trackId").type(JsonFieldType.NUMBER).description("트랙 id"),
-                fieldWithPath("[].content").type(JsonFieldType.STRING).description("트랙 내용")
+                fieldWithPath("[].content").type(JsonFieldType.STRING).description("트랙 내용"),
+                fieldWithPath("[].startDate").type(JsonFieldType.STRING).description("시작 날짜"),
+                fieldWithPath("[].endDate").type(JsonFieldType.STRING).description("종료 날짜"),
+                fieldWithPath("[].trackStatus").type(JsonFieldType.STRING).description("트랙 상태")
         );
     }
 

--- a/module-api/src/test/java/com/gdsc/fixture/DomainFixture.java
+++ b/module-api/src/test/java/com/gdsc/fixture/DomainFixture.java
@@ -7,6 +7,7 @@ import com.gdsc.domain.routine.entity.RoutineStatus;
 import com.gdsc.domain.routine.model.RoutineRequest;
 import com.gdsc.domain.routine.model.RoutineStatusRequest;
 import com.gdsc.domain.track.entity.Track;
+import com.gdsc.domain.track.entity.TrackStatus;
 import com.gdsc.domain.track.model.TrackRequest;
 import com.gdsc.domain.user.entity.Gender;
 import com.gdsc.domain.user.entity.Mood;
@@ -15,6 +16,7 @@ import com.gdsc.domain.user.entity.User;
 import com.gdsc.domain.user.model.UserInfoRequest;
 import com.gdsc.domain.user.model.UserMoodRequest;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -59,33 +61,51 @@ public class DomainFixture {
 
     public static final Track 트랙1 = Track.builder()
             .content("내용1")
+            .trackStatus(TrackStatus.PROCEEDING)
+            .startDate(LocalDate.parse("2024-02-12"))
+            .endDate(LocalDate.parse("2024-02-13"))
             .user(유저1)
             .build();
 
     public static final Track 트랙2 = Track.builder()
             .content("내용2")
+            .trackStatus(TrackStatus.PROCEEDING)
+            .startDate(LocalDate.parse("2024-02-12"))
+            .endDate(LocalDate.parse("2024-02-13"))
             .user(유저1)
             .build();
 
     public static final Track 트랙3 = Track.builder()
             .content("내용3")
+            .trackStatus(TrackStatus.PROCEEDING)
+            .startDate(LocalDate.parse("2024-02-12"))
+            .endDate(LocalDate.parse("2024-02-13"))
             .user(유저1)
             .build();
 
     public static final Track 트랙4 = Track.builder()
             .content("내용1")
+            .trackStatus(TrackStatus.PROCEEDING)
+            .startDate(LocalDate.parse("2024-02-12"))
+            .endDate(LocalDate.parse("2024-02-13"))
             .user(유저2)
             .keyword(키워드1)
             .build();
 
     public static final Track 트랙5 = Track.builder()
             .content("내용2")
+            .trackStatus(TrackStatus.PROCEEDING)
+            .startDate(LocalDate.parse("2024-02-12"))
+            .endDate(LocalDate.parse("2024-02-13"))
             .user(유저2)
             .keyword(키워드1)
             .build();
 
     public static final Track 트랙6 = Track.builder()
             .content("내용3")
+            .trackStatus(TrackStatus.PROCEEDING)
+            .startDate(LocalDate.parse("2024-02-12"))
+            .endDate(LocalDate.parse("2024-02-13"))
             .user(유저2)
             .keyword(키워드1)
             .build();
@@ -154,7 +174,7 @@ public class DomainFixture {
 
     public static final KeywordRequest 유저_키워드_저장_요청1 = new KeywordRequest(List.of("키워드1", "키워드2", "키워드3"));
 
-    public static final TrackRequest 유저_트랙_저장_요청1 = new TrackRequest("내용");
+    public static final TrackRequest 유저_트랙_저장_요청1 = new TrackRequest("내용",LocalDate.parse("2024-02-12"),LocalDate.parse("2024-02-13"));
     public static final RoutineRequest 유저_루틴_저장_요청1 = new RoutineRequest("내용");
     public static final RoutineStatusRequest 유저_루틴_상태_변경_요청1 = new RoutineStatusRequest(RoutineStatus.COMPLETE);
 }

--- a/module-core/src/main/java/com/gdsc/domain/track/entity/Track.java
+++ b/module-core/src/main/java/com/gdsc/domain/track/entity/Track.java
@@ -2,13 +2,16 @@ package com.gdsc.domain.track.entity;
 
 import com.gdsc.domain.keyword.entity.Keyword;
 import com.gdsc.domain.routine.entity.Routine;
+import com.gdsc.domain.routine.entity.RoutineStatus;
 import com.gdsc.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +28,10 @@ public class Track {
     @Column(name = "track_content", nullable = false)
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "track_status", nullable = false)
+    private TrackStatus trackStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -33,13 +40,26 @@ public class Track {
     @JoinColumn(name = "keyword_id")
     private Keyword keyword;
 
+    @Column(name = "track_start_date")
+    LocalDate startDate;
+
+    @Column(name = "track_end_date")
+    LocalDate endDate;
+
     @OneToMany(mappedBy = "track", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Routine> routines;
 
     @Builder
-    public Track(String content, User user, Keyword keyword) {
+    public Track(String content, TrackStatus trackStatus, LocalDate startDate, LocalDate endDate, User user, Keyword keyword) {
         this.content = content;
+        this.trackStatus = trackStatus;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.user = user;
         this.keyword = keyword;
+    }
+
+    public void updateTrackStatus(TrackStatus trackStatus){
+        this.trackStatus = trackStatus;
     }
 }

--- a/module-core/src/main/java/com/gdsc/domain/track/entity/TrackStatus.java
+++ b/module-core/src/main/java/com/gdsc/domain/track/entity/TrackStatus.java
@@ -1,0 +1,5 @@
+package com.gdsc.domain.track.entity;
+
+public enum TrackStatus {
+    PROCEEDING, EXPIRATION
+}

--- a/module-core/src/main/java/com/gdsc/domain/track/repo/TrackRepository.java
+++ b/module-core/src/main/java/com/gdsc/domain/track/repo/TrackRepository.java
@@ -2,6 +2,7 @@ package com.gdsc.domain.track.repo;
 
 import com.gdsc.domain.keyword.entity.Keyword;
 import com.gdsc.domain.track.entity.Track;
+import com.gdsc.domain.track.entity.TrackStatus;
 import com.gdsc.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,4 +16,6 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     Optional<List<Track>> findByUser(User user);
 
     void deleteByUser(User user);
+
+    Optional<List<Track>> findByTrackStatus(TrackStatus trackStatus);
 }


### PR DESCRIPTION
## :sparkles: 이슈 번호: #28 


## :bulb: 상세 내용:
* track entity에 status, startDate, endDate 필드 추가
* track status, date api 구현
* trackStatus가 매일 0시에 endDate와 비교하여 update되는 로직 구현

